### PR TITLE
Improve website with lessons and practice pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# Project-shalom
-Cybersecurity learning
+# Project Shalom Cybersecurity Learning Platform
+
+This repository provides a small bilingual website that helps Australians transition into the cybersecurity field. It contains basic learning material and an interactive quiz. All pages include both English and Chinese text.
+
+## Getting Started
+
+1. Clone the repo and open `index.html` in your browser.
+2. Navigate to the **Lessons** page to read introductory material.
+3. Visit the **Practice** page to try the quiz plugin.
+
+To view the site via a local server, run `python3 -m http.server` in the project directory and open `http://localhost:8000` in your browser.
+
+---
+
+该项目为想在澳大利亚转行网络安全的人提供一个包含基础教学与实践的小型双语网站。
+
+1. 克隆仓库后在浏览器中打开 `index.html`。
+2. 进入 **Lessons / 课程** 页面阅读入门内容。
+3. 在 **Practice / 实践** 页面参与小测验。
+
+如需通过本地服务器访问站点，可在项目目录下执行 `python3 -m http.server`，然后在浏览器打开 `http://localhost:8000`。

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,24 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2em;
+  background-color: #f9f9f9;
+}
+
+header, section {
+  margin-bottom: 2em;
+}
+
+nav a {
+  margin-right: 1em;
+  text-decoration: none;
+  color: #0366d6;
+}
+
+#quiz-area {
+  margin-top: 1em;
+}
+
+#score {
+  margin-top: 1em;
+  font-weight: bold;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Shalom Cybersecurity Learning</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Shalom Cybersecurity Learning / 安全学习</h1>
+    <nav>
+      <a href="lessons.html">Lessons / 课程</a> |
+      <a href="practice.html">Practice / 实践</a>
+    </nav>
+    <p>Welcome to the bilingual cybersecurity learning site for people in Australia looking to change careers.</p>
+    <p>欢迎想在澳大利亚转行进入网络安全领域的朋友来到这个双语学习网站。</p>
+  </header>
+
+  <section>
+    <h2>About This Site / 关于本站</h2>
+    <p>The goal is to provide beginner-to-expert resources so you can study at home without formal classes.</p>
+    <p>我们的目标是提供从入门到专家的资料，让你无需上课也能在家学习。</p>
+  </section>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,51 @@
+(function() {
+  const quizData = [
+    { q: 'What does CIA stand for in cybersecurity?', a: 'confidentiality, integrity, availability' },
+    { q: '在网络安全中，常见的端口号80对应的服务是什么？', a: 'HTTP' }
+  ];
+
+  const quizArea = document.getElementById('quiz-area');
+  const startBtn = document.getElementById('start-quiz');
+  const scoreDiv = document.getElementById('score');
+
+  if (!quizArea || !startBtn) return;
+
+  function startQuiz() {
+    quizArea.innerHTML = '';
+    scoreDiv.textContent = '';
+    quizData.forEach(item => {
+      const div = document.createElement('div');
+      const label = document.createElement('label');
+      label.textContent = item.q;
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.dataset.answer = item.a.toLowerCase();
+      div.appendChild(label);
+      div.appendChild(document.createElement('br'));
+      div.appendChild(input);
+      quizArea.appendChild(div);
+    });
+    const submit = document.createElement('button');
+    submit.textContent = 'Check Answers / \u68c0\u67e5\u7b54\u6848';
+    submit.onclick = checkAnswers;
+    quizArea.appendChild(document.createElement('br'));
+    quizArea.appendChild(submit);
+  }
+
+  function checkAnswers() {
+    const inputs = quizArea.querySelectorAll('input');
+    let score = 0;
+    inputs.forEach(input => {
+      const val = input.value.trim().toLowerCase();
+      if (val === input.dataset.answer) {
+        score++;
+        input.style.borderColor = 'green';
+      } else {
+        input.style.borderColor = 'red';
+      }
+    });
+    scoreDiv.textContent = 'Score: ' + score + ' / ' + inputs.length;
+  }
+
+  startBtn.addEventListener('click', startQuiz);
+})();

--- a/lessons.html
+++ b/lessons.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lessons - Shalom Cybersecurity</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Cybersecurity Lessons / 网络安全课程</h1>
+    <nav>
+      <a href="index.html">Home / 首页</a> |
+      <a href="practice.html">Practice / 实践</a>
+    </nav>
+  </header>
+
+  <section>
+    <h2>Introduction / 简介</h2>
+    <p>This section introduces the basics of cybersecurity for newcomers.</p>
+    <p>本节面向初学者介绍网络安全的基础知识。</p>
+  </section>
+
+  <section>
+    <h2>Key Topics / 关键主题</h2>
+    <ul>
+      <li>Network fundamentals / 网络基础</li>
+      <li>Common threats / 常见威胁</li>
+      <li>Security best practices / 安全最佳实践</li>
+    </ul>
+    <p>These topics help you build a solid foundation for a career transition.</p>
+    <p>这些主题帮助你为转行网络安全打下坚实的基础。</p>
+  </section>
+
+  <section>
+    <h2>Further Learning / 深入学习</h2>
+    <p>After covering the basics, explore these resources to continue growing your knowledge.</p>
+    <p>在掌握基础后，可通过以下资源进一步提升：</p>
+    <ul>
+      <li>Online labs and challenges / 在线练习与挑战</li>
+      <li>Certification paths (CompTIA, CISSP, etc.) / 认证路线（如 CompTIA、CISSP）</li>
+      <li>Local cybersecurity communities in Australia / 澳大利亚本地安全社区</li>
+    </ul>
+  </section>
+</body>
+</html>

--- a/practice.html
+++ b/practice.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Practice - Shalom Cybersecurity</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <h1>Practice Quiz / 练习测试</h1>
+    <nav>
+      <a href="index.html">Home / 首页</a> |
+      <a href="lessons.html">Lessons / 课程</a>
+    </nav>
+    <p>Test your knowledge with this short quiz.</p>
+    <p>通过此小测验来检验你的知识。</p>
+  </header>
+
+  <section id="practice">
+    <div id="quiz-area"></div>
+    <button id="start-quiz">Start Quiz / 开始测试</button>
+    <div id="score"></div>
+  </section>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,0 +1,20 @@
+import os
+
+
+def test_index_exists():
+    assert os.path.exists('index.html')
+
+
+def test_lessons_exists():
+    assert os.path.exists('lessons.html')
+
+
+def test_practice_exists():
+    assert os.path.exists('practice.html')
+
+
+def test_pages_contain_chinese():
+    for page in ['index.html', 'lessons.html', 'practice.html']:
+        with open(page, encoding='utf-8') as f:
+            data = f.read()
+        assert '双语' in data or '课程' in data or '练习测试' in data


### PR DESCRIPTION
## Summary
- create a simple bilingual landing page with navigation
- add new Lessons and Practice pages
- refine quiz script to handle missing elements gracefully
- style navigation links
- expand README and tests for new pages
- add further learning section and local server instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673be4e97c8333898137f905a727e6